### PR TITLE
Add sanity script to comply with PEP8

### DIFF
--- a/.pycodestylerc
+++ b/.pycodestylerc
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = True
+ignore = D100, D103, W504, W503
+max-line-length = 120
+exclude=migrations*, docs*

--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,0 +1,3 @@
+[pydocstyle]
+convention=numpy
+match-dir="^(?!migrations)^(?!env).*"

--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,3 +1,3 @@
 [pydocstyle]
 convention=numpy
-match-dir="^(?!migrations)^(?!env).*"
+match-dir="^(?!docs)^(?!env)^(?!migrations).*"

--- a/iqps/accounts/views.py
+++ b/iqps/accounts/views.py
@@ -1,6 +1,7 @@
 import logging
-from django.shortcuts import render, redirect
-from django.contrib.auth import authenticate, login, logout
+
+from django.contrib.auth import authenticate, get_user_model, login, logout
+from django.shortcuts import redirect, render
 
 from .forms import UserLoginForm, UserRegisterForm
 

--- a/iqps/data/admin.py
+++ b/iqps/data/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
-from .models import Paper, Keyword, Department
+from .models import Department, Keyword, Paper
+
 
 
 class PaperAdmin(admin.ModelAdmin):

--- a/iqps/data/models.py
+++ b/iqps/data/models.py
@@ -45,8 +45,8 @@ class Paper(models.Model):
                                            max_value_current_year])
     added_on = models.DateTimeField(auto_now_add=True)
 
-    keywords = models.ManyToManyField(Keyword, blank=True,
-                                      related_name="papers")
+    keywords = models.ManyToManyField(
+        Keyword, blank=True, related_name="papers")
 
     class Meta:
         db_table = 'papers'

--- a/iqps/data/views.py
+++ b/iqps/data/views.py
@@ -1,4 +1,5 @@
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import render
 
 from .models import Paper
 

--- a/iqps/frontend/forms.py
+++ b/iqps/frontend/forms.py
@@ -1,4 +1,3 @@
-from data.models import PAPER_TYPES, Department, Keyword
 from django import forms
 from django_select2.forms import Select2MultipleWidget, Select2Widget
 from data.models import PAPER_TYPES, Department, Keyword
@@ -8,6 +7,8 @@ from utils.timeutil import current_year
 def year_choices():
     base_choices = [(r, r) for r in range(current_year(), 1950, -1)]
     return [('', '')] + base_choices
+
+from data.models import PAPER_TYPES, Department, Keyword
 
 
 class FilterForm(forms.Form):

--- a/iqps/frontend/forms.py
+++ b/iqps/frontend/forms.py
@@ -1,3 +1,4 @@
+from data.models import PAPER_TYPES, Department, Keyword
 from django import forms
 from django_select2.forms import Select2MultipleWidget, Select2Widget
 from data.models import PAPER_TYPES, Department, Keyword

--- a/iqps/frontend/views.py
+++ b/iqps/frontend/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+
 from .forms import FilterForm
 
 

--- a/iqps/iqps/settings.py
+++ b/iqps/iqps/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 import os.path
+
 from dotenv import load_dotenv
 
 load_dotenv(os.path.join('conf', 'app.env'))
@@ -30,11 +31,11 @@ SECRET_KEY = os.environ['SECRET_KEY']
 DEBUG = True if os.environ.get("MODE", "dev") == "dev" else False
 
 ALLOWED_HOSTS = [
-        "localhost",
-        "127.0.0.1",
-        "0.0.0.0",
-        os.environ.get("CNAME", ".ngrok.io")
-    ]
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    os.environ.get("CNAME", ".ngrok.io")
+]
 
 
 # Application definition
@@ -173,5 +174,3 @@ LOGGING = {
         }
     }
 }
-
-

--- a/iqps/iqps/urls.py
+++ b/iqps/iqps/urls.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 
 admin.site.site_header = "MFQP Administration"
 

--- a/iqps/report/admin.py
+++ b/iqps/report/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import Report
 
 admin.site.register(Report)

--- a/iqps/report/forms.py
+++ b/iqps/report/forms.py
@@ -1,5 +1,6 @@
-from django import forms
 from captcha.fields import CaptchaField
+from django import forms
+
 from .models import Report
 
 

--- a/iqps/report/models.py
+++ b/iqps/report/models.py
@@ -1,5 +1,6 @@
-from data.models import Paper
 from django.db import models
+
+from data.models import Paper
 
 
 class Report(models.Model):

--- a/iqps/report/models.py
+++ b/iqps/report/models.py
@@ -1,5 +1,5 @@
-from django.db import models
 from data.models import Paper
+from django.db import models
 
 
 class Report(models.Model):

--- a/iqps/report/views.py
+++ b/iqps/report/views.py
@@ -1,7 +1,9 @@
-from django.shortcuts import render, get_object_or_404
-from django.contrib import messages
-from .forms import ReportForm
 from data.models import Paper
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, render
+
+from .forms import ReportForm
+
 
 
 def reportPaper(request, paperId):

--- a/iqps/report/views.py
+++ b/iqps/report/views.py
@@ -1,6 +1,7 @@
-from data.models import Paper
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, render
+
+from data.models import Paper
 
 from .forms import ReportForm
 

--- a/iqps/request/admin.py
+++ b/iqps/request/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import PaperRequest
 
 admin.site.register(PaperRequest)

--- a/iqps/request/forms.py
+++ b/iqps/request/forms.py
@@ -1,5 +1,6 @@
-from django import forms
 from captcha.fields import CaptchaField
+from django import forms
+
 from .models import PaperRequest
 
 

--- a/iqps/request/models.py
+++ b/iqps/request/models.py
@@ -1,5 +1,6 @@
-from data.models import PAPER_TYPES
 from django.db import models
+
+from data.models import PAPER_TYPES
 
 
 

--- a/iqps/request/models.py
+++ b/iqps/request/models.py
@@ -1,5 +1,6 @@
-from django.db import models
 from data.models import PAPER_TYPES
+from django.db import models
+
 
 
 class PaperRequest(models.Model):

--- a/iqps/request/views.py
+++ b/iqps/request/views.py
@@ -1,7 +1,7 @@
 import logging
 
-from django.shortcuts import render
 from django.contrib import messages
+from django.shortcuts import render
 
 from .forms import RequestForm
 from .models import PaperRequest

--- a/iqps/search/processors.py
+++ b/iqps/search/processors.py
@@ -1,4 +1,5 @@
 import sqlite3
+
 from fuzzywuzzy import fuzz
 
 
@@ -18,8 +19,8 @@ class SearchCursor:
 
     def __enter__(self):
         self.connection = sqlite3.connect(self.db_name)
-        self.connection.create_function("SIMILARITYSCORE", 2,
-                                        self._similarityScore)
+        self.connection.create_function(
+            "SIMILARITYSCORE", 2, self._similarityScore)
         self.cursor = self.connection.cursor()
 
         return self.cursor

--- a/iqps/search/views.py
+++ b/iqps/search/views.py
@@ -1,6 +1,7 @@
 from django.db import connection
 from django.http import JsonResponse
 from django.shortcuts import render
+
 from iqps.settings import DATABASES
 from .processors import SearchCursor
 

--- a/iqps/search/views.py
+++ b/iqps/search/views.py
@@ -1,6 +1,6 @@
 from django.db import connection
 from django.http import JsonResponse
-
+from django.shortcuts import render
 from iqps.settings import DATABASES
 from .processors import SearchCursor
 

--- a/iqps/upload/forms.py
+++ b/iqps/upload/forms.py
@@ -1,13 +1,14 @@
 import logging
 
 from captcha.fields import CaptchaField
-from data.models import Keyword, Paper
 from django import forms
 from django_select2.forms import ModelSelect2TagWidget, Select2Widget
 from captcha.fields import CaptchaField
 
 from data.models import Paper, Keyword
 from utils.timeutil import current_year
+
+from data.models import Keyword, Paper
 
 LOG = logging.getLogger(__name__)
 

--- a/iqps/upload/forms.py
+++ b/iqps/upload/forms.py
@@ -1,4 +1,7 @@
 import logging
+
+from captcha.fields import CaptchaField
+from data.models import Keyword, Paper
 from django import forms
 from django_select2.forms import ModelSelect2TagWidget, Select2Widget
 from captcha.fields import CaptchaField
@@ -81,7 +84,7 @@ class UploadForm(forms.ModelForm):
         widgets = {
             'keywords': KeywordSelect2TagWidget,
             'department': Select2Widget
-            }
+        }
         labels = {
             'department': 'Department (Prefer 2 letter codes. \
                           Select Others if not found)'

--- a/iqps/upload/google_connect.py
+++ b/iqps/upload/google_connect.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
-import pickle
+
 import os.path
+import pickle
+
+from google.auth.transport.requests import Request
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
 # Source: Google Drive API Python Quickstart
 

--- a/iqps/upload/views.py
+++ b/iqps/upload/views.py
@@ -3,10 +3,11 @@ import logging
 import os
 import uuid
 
-from data.models import Department, Keyword, Paper
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
+
+from data.models import Department, Keyword, Paper
 from iqps.settings import GDRIVE_DIRNAME, STATICFILES_DIRS
 from request.models import PaperRequest
 

--- a/iqps/upload/views.py
+++ b/iqps/upload/views.py
@@ -1,22 +1,24 @@
 import json
 import logging
-import uuid
 import os
-from django.shortcuts import render
-# from django.contrib.auth.decorators import login_required
-from django.contrib import messages
+import uuid
 
-from data.models import Paper, Department
+from data.models import Department, Keyword, Paper
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
+from iqps.settings import GDRIVE_DIRNAME, STATICFILES_DIRS
 from request.models import PaperRequest
-from iqps.settings import STATICFILES_DIRS, GDRIVE_DIRNAME
+
 from .forms import BulkUploadForm, UploadForm
-from .google_connect import upload_file, get_or_create_folder
+from .google_connect import get_or_create_folder, upload_file
 
 GDRIVE_DIR_ID = None
 LOG = logging.getLogger(__name__)
 
-
 # @login_required
+
+
 def index(request):
     global GDRIVE_DIR_ID
 
@@ -36,8 +38,8 @@ def index(request):
                     for chunk in file.chunks():
                         dest.write(chunk)
                 if not GDRIVE_DIR_ID:
-                    GDRIVE_DIR_ID = get_or_create_folder(GDRIVE_DIRNAME,
-                                                         public=True)
+                    GDRIVE_DIR_ID = get_or_create_folder(
+                        GDRIVE_DIRNAME, public=True)
                 paper = upl.save(commit=False)
                 paper.link = upload_file(path, "{}.pdf".format(uid),
                                          folderId=GDRIVE_DIR_ID)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alabaster==0.7.12
 asgiref==3.2.5
+astroid==2.4.2
 Babel==2.8.0
 beautifulsoup4==4.9.0
 bs4==0.0.1
@@ -14,6 +15,7 @@ django-select2==7.2.3
 django-simple-captcha==0.5.12
 djangorestframework==3.11.0
 docutils==0.16
+dodgy==0.2.1
 download==0.3.4
 fuzzywuzzy==0.18.0
 google-api-core==1.16.0
@@ -26,10 +28,13 @@ gunicorn==20.0.4
 httplib2==0.17.1
 idna==2.9
 imagesize==1.2.0
+isort==4.3.21
 Jinja2==2.11.2
 joblib==0.14.1
+lazy-object-proxy==1.4.3
 Markdown==3.2.1
 MarkupSafe==1.1.1
+mccabe==0.6.1
 mysqlclient==1.4.6
 nltk==3.4.5
 numpy==1.18.2
@@ -41,7 +46,9 @@ Pillow==7.0.0
 protobuf==3.11.3
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
+pydocstyle==5.0.2
 Pygments==2.6.1
+pylint==2.5.3
 pyparsing==2.4.7
 pytesseract==0.3.3
 python-dateutil==2.8.1
@@ -65,6 +72,9 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sqlparse==0.3.1
+toml==0.10.1
 tqdm==4.43.0
+typed-ast==1.4.1
 uritemplate==3.0.1
 urllib3==1.25.8
+wrapt==1.12.1

--- a/sanity.sh
+++ b/sanity.sh
@@ -1,4 +1,4 @@
-dodgy --ignore paths venv env migrations scripts
+dodgy --ignore paths venv env docs
 isort -rc --atomic ./ -sg "*/migrations/*.py" -sg "*/docs/*.py"
 pydocstyle --config=./.pydocstylerc
 pycodestyle ./ --config=./.pycodestylerc

--- a/sanity.sh
+++ b/sanity.sh
@@ -1,4 +1,4 @@
 dodgy --ignore paths venv env migrations scripts
-isort -rc --atomic ./ -sg "*/migrations/*.py"
+isort -rc --atomic ./ -sg "*/migrations/*.py" -sg "*/docs/*.py"
 pydocstyle --config=./.pydocstylerc
 pycodestyle ./ --config=./.pycodestylerc

--- a/sanity.sh
+++ b/sanity.sh
@@ -1,0 +1,4 @@
+dodgy --ignore paths venv env migrations scripts
+isort -rc --atomic ./ -sg "*/migrations/*.py"
+pydocstyle --config=./.pydocstylerc
+pycodestyle ./ --config=./.pycodestylerc

--- a/scripts/keywordProcessor.py
+++ b/scripts/keywordProcessor.py
@@ -1,15 +1,17 @@
-import json
 import fcntl
+import json
 import os
 import string
-from pdf2image import convert_from_path
-from sklearn.feature_extraction.text import TfidfVectorizer
-from nltk.corpus import stopwords
-from nltk import word_tokenize
+
 import pytesseract
+from nltk import word_tokenize
+from nltk.corpus import stopwords
+from pdf2image import convert_from_path
 from PIL import Image
+from sklearn.feature_extraction.text import TfidfVectorizer
 
 CORPUS = []
+
 
 def load_corpus():
     global CORPUS
@@ -28,6 +30,7 @@ def load_corpus():
                 json.dump(CORPUS, f)
                 os.fsync(f.fileno())
                 fcntl.lockf(f, fcntl.LOCK_UN)
+
 
 def append_corpus(new_corpus):
     """
@@ -50,6 +53,7 @@ def append_corpus(new_corpus):
             os.fsync(f.fileno())
             fcntl.lockf(f, fcntl.LOCK_UN)
 
+
 def extract_text(path):
     """
     Takes the pdf file from fpath and extracts text from it.
@@ -59,7 +63,8 @@ def extract_text(path):
     for page in pages:
         text += str(pytesseract.image_to_string(page))
     return text
-    
+
+
 def extract_keyword(text, dry_run=False, commit=True):
     load_corpus()
 
@@ -69,9 +74,9 @@ def extract_keyword(text, dry_run=False, commit=True):
     text = word_tokenize(text)
     stoppers = set(stopwords.words('english'))
     text = " ".join([w for w in text if w not in stoppers])
-        
+
     CORPUS.append(text)
-    
+
     if commit:
         append_corpus([text])
     if not dry_run:
@@ -91,5 +96,3 @@ def extract_keyword(text, dry_run=False, commit=True):
         return keywords
     else:
         return []
-
-

--- a/scripts/pdfFinder.py
+++ b/scripts/pdfFinder.py
@@ -5,7 +5,6 @@ from collections import deque, namedtuple
 from urllib.parse import urlparse
 
 import requests
-
 from bs4 import BeautifulSoup
 
 Node = namedtuple("Node", ["link", "parent", "grandparent"])


### PR DESCRIPTION
This PR adds a `sanity.sh` script that can be run to ensure there are no PEP8 errors. It uses the configurations defined in `.pycodestylerc` and `.pydocstylerc` to run checks. 