### PR TITLE
Add sanity script

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,9 @@
+scanner:
+    diff_only: True  # If False, the entire file touched by the Pull Request is scanned for errors. If True, only the diff is scanned.
+    linter: pycodestyle  # Other option is flake8
+
+pycodestyle:  # Same as scanner.linter value. Other option is flake8
+    max-line-length: 120  # Default is 79 in PEP 8
+    ignore:  # Errors and warnings to ignore
+        - W504  # line break after binary operator
+        - W503  # line break before binary operator

--- a/.pycodestylerc
+++ b/.pycodestylerc
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = True
+ignore = D100, D103, W504, W503
+max-line-length = 120
+exclude=migrations*, docs*

--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,0 +1,3 @@
+[pydocstyle]
+convention=numpy
+match-dir="^(?!docs)^(?!env)^(?!migrations).*"

--- a/sanity.sh
+++ b/sanity.sh
@@ -1,0 +1,4 @@
+dodgy --ignore paths venv env docs migrations
+isort -rc --atomic ./ -sg "*/migrations/*.py" -sg "*/docs/*.py"
+pydocstyle --config=./.pydocstylerc
+pycodestyle ./ --config=./.pycodestylerc


### PR DESCRIPTION
This PR adds a sanity script (`sanity.sh`) that can be run before every commit to make sure the code follows PEP8 conventions. Settings for the script are defined in `.pycodestylerc` and `.pydocstylerc`. 

pep8speaks is also configured to follow max line length limit of 120 as defined in `.pycodestyle` to make sure both are consistent. 