### PR TITLE
[FEATURE] Give Option To Upload File or Paste Link

### DIFF
--- a/iqps/upload/forms.py
+++ b/iqps/upload/forms.py
@@ -60,6 +60,7 @@ class BulkUploadForm(forms.Form):
 class UploadForm(forms.ModelForm):
     file = forms.FileField(widget=forms.ClearableFileInput,
                            label="Upload pdf")
+    file_link = forms.URLInput(label="Enter link to paper PDF, if NOT uploading file!")
     year = forms.TypedChoiceField(coerce=int, choices=year_choices,
                                   initial=current_year)
     captcha = CaptchaField()
@@ -75,7 +76,8 @@ class UploadForm(forms.ModelForm):
             'year',
             'paper_type',
             'file',
-            'keywords'
+            'keywords',
+            'link'
         ]
 
         widgets = {
@@ -90,9 +92,12 @@ class UploadForm(forms.ModelForm):
     def clean(self, *args, **kwargs):
         try:
             f = self.files.get("file")
-            assert f is not None
-            assert "pdf" in f.content_type
+            l = self.file_link
+            if f is None and l is None:
+                raise AssertionError("neither file nor link uploaded!")
+            if f is not None:
+                assert "pdf" in f.content_type
         except Exception:
-            raise forms.ValidationError("Invalid File")
+            raise forms.ValidationError("Invalid File or Link")
         finally:
             super(UploadForm, self).clean(*args, **kwargs)

--- a/iqps/upload/forms.py
+++ b/iqps/upload/forms.py
@@ -60,7 +60,7 @@ class BulkUploadForm(forms.Form):
 class UploadForm(forms.ModelForm):
     file = forms.FileField(widget=forms.ClearableFileInput,
                            label="Upload pdf")
-    file_link = forms.URLInput(label="Enter link to paper PDF, if NOT uploading file!")
+    file_link = forms.URLInput(label="Link to paper, if NOT uploading file!")
     year = forms.TypedChoiceField(coerce=int, choices=year_choices,
                                   initial=current_year)
     captcha = CaptchaField()
@@ -92,8 +92,8 @@ class UploadForm(forms.ModelForm):
     def clean(self, *args, **kwargs):
         try:
             f = self.files.get("file")
-            l = self.file_link
-            if f is None and l is None:
+            link = self.file_link
+            if f is None and link is None:
                 raise AssertionError("neither file nor link uploaded!")
             if f is not None:
                 assert "pdf" in f.content_type

--- a/iqps/upload/forms.py
+++ b/iqps/upload/forms.py
@@ -60,7 +60,7 @@ class BulkUploadForm(forms.Form):
 class UploadForm(forms.ModelForm):
     file = forms.FileField(widget=forms.ClearableFileInput,
                            label="Upload pdf")
-    file_link = forms.URLInput(label="Link to paper, if NOT uploading file!")
+    file_link = forms.URLField(label="Link to paper, if NOT uploading file!")
     year = forms.TypedChoiceField(coerce=int, choices=year_choices,
                                   initial=current_year)
     captcha = CaptchaField()

--- a/iqps/upload/google_connect.py
+++ b/iqps/upload/google_connect.py
@@ -48,6 +48,7 @@ def upload_file(local_path, remote_name, folderId=None, service=None):
     file = service.files().create(body=file_metadata,
                                   media_body=media,
                                   fields='webContentLink').execute()
+    os.remove(local_path)
     return file.get('webContentLink', None)
 
 

--- a/iqps/upload/views.py
+++ b/iqps/upload/views.py
@@ -38,9 +38,9 @@ def index(request):
                             dest.write(chunk)
                     if not GDRIVE_DIR_ID:
                         GDRIVE_DIR_ID = get_or_create_folder(GDRIVE_DIRNAME,
-                                                            public=True)
+                                                             public=True)
                     link = upload_file(path, "{}.pdf".format(uid),
-                                            folderId=GDRIVE_DIR_ID)
+                                       folderId=GDRIVE_DIR_ID)
                 paper = upl.save(commit=False)
                 if link is not None:
                     paper.link = link

--- a/iqps/upload/views.py
+++ b/iqps/upload/views.py
@@ -27,6 +27,7 @@ def index(request):
             # UploadForm is submitted
             upl = UploadForm(request.POST, request.FILES)
             if upl.is_valid():
+                link = None
                 if request.FILES.get('file') is not None:
                     path = STATICFILES_DIRS[0]
                     uid = uuid.uuid4()
@@ -38,14 +39,13 @@ def index(request):
                     if not GDRIVE_DIR_ID:
                         GDRIVE_DIR_ID = get_or_create_folder(GDRIVE_DIRNAME,
                                                             public=True)
+                    link = upload_file(path, "{}.pdf".format(uid),
+                                            folderId=GDRIVE_DIR_ID)
                 paper = upl.save(commit=False)
-                if paper.link is None:
-                    paper.link = upload_file(path, "{}.pdf".format(uid),
-                                             folderId=GDRIVE_DIR_ID)
+                if link is not None:
+                    paper.link = link
+
                 keys_tmp = upl.cleaned_data.get("keywords")
-
-                paper.save()
-
                 for key in keys_tmp:
                     paper.keywords.add(key)
 


### PR DESCRIPTION
This PR, if merged, will implement the following changes:

- Give the user the option to either upload a file or add a link (to the already uploaded file somewhere else).
- `os.remove(local_path)` happens in the `upload_file` function since it makes more sense that as soon as a file is uploaded, it should be removed.

NOTE: You can try to make this command `async`.

- Validation has been accordingly changed to allow passing given either of the link or file has been provided in the form.
- Logging messages have been modified accordingly.
- Remove double `paper.save()` and save only after adding keywords. (@grapheo12 Was two saves something you intended?)

I believe earlier we decided that this should be an option available only to admin but I realized that it could happen sometimes that a user may find a paper on other website such as notehub etc. and would want to link them to mfqp. The same goes in case we are missing a file from library. So, I have made it available to admin and non-admin.

P.S. As with the last PR, I haven't set up a local copy of the application since I'm facing some issues with the database on my Ubuntu version (and I didn't have much time to inspect the issue). Please pardon the same, and test the changes before deploying.

fixes #9 