### PR TITLE
Add External Network configuration in docker-compose.yml.template

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -5,16 +5,6 @@ networks:
 
 
 services:
-  nginx:
-    build: ./nginx
-    volumes:
-      - local_static_root_path:/var/www/static/
-    ports:
-      - "8001:8001"
-    networks:
-      main-network:
-    depends_on:
-      - web
   db:
     image: mariadb:latest
     restart: always
@@ -38,6 +28,9 @@ services:
       - local_log_path:/var/log/iqps/
     networks:
       main-network:
+      nginx_network:
+        aliases:
+          - iqps_web
     depends_on:
       - db
   backup:
@@ -47,6 +40,8 @@ services:
        DROPBOX_ACCESS_TOKEN: 'DROPBOX_TOKEN'
     networks:
       main-network:
+      external:
+        nginx_network:
     depends_on:
       - db    
     

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -41,7 +41,7 @@ services:
     networks:
       main-network:
       external:
-        nginx_network:
+        name: nginx_network
     depends_on:
       - db    
     


### PR DESCRIPTION
The PR, if merged, will add the external network for Nginx serving in the template docker-compose.yml

This needs to be served in conjunction with https://github.com/grapheo12/ingress